### PR TITLE
fix: use corepack enable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         node-version: [22]
-        pnpm-version: [10]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,10 +19,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: ${{ matrix.pnpm-version }}
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
## reason

```
[Release (22, 10)](https://github.com/akccakcctw/kk-bendon-helper/actions/runs/13746820092/job/38442771138#step:3:18)
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.6.1 in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```